### PR TITLE
Fixed MacOS build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ set(COMMON_SOURCE
 
 if (APPLE)
     set(PLATFORM_SOURCE
-        ${COMMON_SOURCE_DIR}/Platform/OSX/CoreAudio.mm
+        app/OSX/CoreAudio.mm
       )
 
 elseif (UNIX)


### PR DESCRIPTION
This fixes the issue where the MacOS version won't build due to a missing file.